### PR TITLE
feat: style the "Stream it your way" section + tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ This is a **WIP**! 🤫
     - [x] Blurry topbar background?
   - [x] Sidebar navigation?
 - [x] Header/Hero/Album?
-- [ ] Streaming?
-  - [ ] Tooltips?
+- [x] Streaming?
+  - [x] Tooltips?
 - [ ] Track List?
 - [ ] Music Video?
 - [ ] Footer?

--- a/index.html
+++ b/index.html
@@ -175,28 +175,28 @@
         <!-- Platform icons -->
         <div class="flex items-center">
           <!-- Add "relative" to each button -->
-          <button class="bordered-button group relative flex items-center gap-2 py-3.1! border-l-2">
+          <a class="bordered-button group relative flex items-center gap-2 py-3.1! border-l-2">
             <img class="social-icon" src="assets/icons/play-button.png" alt="Stream it on Monstercat player">
             <span class="text-xs">PLAYER</span>
             <div class="tooltip group-hover:opacity-100">STREAM ON MONSTERCAT PLAYER</div>
           </button>
-          <button class="bordered-button group relative">
+          <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/bandcamp.png" alt="Stream it on Bandcamp">
             <div class="tooltip">STREAM ON BANDCAMP</div>
           </button>
-          <button class="bordered-button group relative">
+          <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/soundcloud.png" alt="Stream it on Soundcloud">
             <div class="tooltip group-hover:opacity-100">STREAM ON SOUNDCLOUD</div>
           </button>
-          <button class="bordered-button group relative">
+          <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/apple.png" alt="Stream it on Apple Music">
             <div class="tooltip group-hover:opacity-100">STREAM ON APPLE</div>
           </button>
-          <button class="bordered-button group relative">
+          <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/youtube.png" alt="Stream it on Youtube">
             <div class="tooltip group-hover:opacity-100">STREAM ON YOUTUBE</div>
           </button>
-          <button class="bordered-button group relative">
+          <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/spotify.png" alt="Stream it on Spotify">
             <div class="tooltip group-hover:opacity-100">STREAM ON SPOTIFY</div>
           </button>

--- a/index.html
+++ b/index.html
@@ -26,13 +26,13 @@
 
               <!-- Socials (top) -->
               <div class="hidden gap-5.5 sm:flex lg:hidden">
-                <a href=""><img class="nav-social-icon" src="assets/icons/instagram.png" alt="Instagram"></a>
-                <a href=""><img class="nav-social-icon" src="assets/icons/tik-tok.png" alt="Tiktok"></a>
-                <a href=""><img class="nav-social-icon" src="assets/icons/twitter.png" alt="Twitter"></a>
-                <a href=""><img class="nav-social-icon" src="assets/icons/twitch.png" alt="Twitch"></a>
-                <a href=""><img class="nav-social-icon" src="assets/icons/facebook.png" alt="Facebook"></a>
-                <a href=""><img class="nav-social-icon" src="assets/icons/discord.png" alt="Discord"></a>
-                <a href=""><img class="nav-social-icon" src="assets/icons/play-button.png" alt="Monstercat Player"></a>
+                <a href=""><img class="social-icon" src="assets/icons/instagram.png" alt="Instagram"></a>
+                <a href=""><img class="social-icon" src="assets/icons/tik-tok.png" alt="Tiktok"></a>
+                <a href=""><img class="social-icon" src="assets/icons/twitter.png" alt="Twitter"></a>
+                <a href=""><img class="social-icon" src="assets/icons/twitch.png" alt="Twitch"></a>
+                <a href=""><img class="social-icon" src="assets/icons/facebook.png" alt="Facebook"></a>
+                <a href=""><img class="social-icon" src="assets/icons/discord.png" alt="Discord"></a>
+                <a href=""><img class="social-icon" src="assets/icons/play-button.png" alt="Monstercat Player"></a>
               </div>
 
               <!-- hamburger menu -->
@@ -41,13 +41,13 @@
 
             <!-- Socials (side) -->
             <div class="hidden flex-col items-end gap-5.5 pr-2 lg:flex">
-              <a href=""><img class="nav-social-icon" src="assets/icons/instagram.png" alt="Instagram"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/tik-tok.png" alt="Tiktok"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/twitter.png" alt="Twitter"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/twitch.png" alt="Twitch"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/facebook.png" alt="Facebook"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/discord.png" alt="Discord"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/play-button.png" alt="Monstercat Player"></a>
+              <a href=""><img class="social-icon" src="assets/icons/instagram.png" alt="Instagram"></a>
+              <a href=""><img class="social-icon" src="assets/icons/tik-tok.png" alt="Tiktok"></a>
+              <a href=""><img class="social-icon" src="assets/icons/twitter.png" alt="Twitter"></a>
+              <a href=""><img class="social-icon" src="assets/icons/twitch.png" alt="Twitch"></a>
+              <a href=""><img class="social-icon" src="assets/icons/facebook.png" alt="Facebook"></a>
+              <a href=""><img class="social-icon" src="assets/icons/discord.png" alt="Discord"></a>
+              <a href=""><img class="social-icon" src="assets/icons/play-button.png" alt="Monstercat Player"></a>
             </div>
 
           </nav>
@@ -94,13 +94,13 @@
 
             <!-- Socials -->
             <div class="flex gap-5 ml-1">
-              <a href=""><img class="nav-social-icon" src="assets/icons/instagram.png" alt="Instagram"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/tik-tok.png" alt="Tiktok"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/twitter.png" alt="Twitter"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/twitch.png" alt="Twitch"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/facebook.png" alt="Facebook"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/discord.png" alt="Discord"></a>
-              <a href=""><img class="nav-social-icon" src="assets/icons/play-button.png" alt="Monstercat Player"></a>
+              <a href=""><img class="social-icon" src="assets/icons/instagram.png" alt="Instagram"></a>
+              <a href=""><img class="social-icon" src="assets/icons/tik-tok.png" alt="Tiktok"></a>
+              <a href=""><img class="social-icon" src="assets/icons/twitter.png" alt="Twitter"></a>
+              <a href=""><img class="social-icon" src="assets/icons/twitch.png" alt="Twitch"></a>
+              <a href=""><img class="social-icon" src="assets/icons/facebook.png" alt="Facebook"></a>
+              <a href=""><img class="social-icon" src="assets/icons/discord.png" alt="Discord"></a>
+              <a href=""><img class="social-icon" src="assets/icons/play-button.png" alt="Monstercat Player"></a>
             </div>
 
             <!-- Sign in/up -->
@@ -137,8 +137,8 @@
 
           <!-- Album title(?) + Artist -->
           <div class="flex flex-col gap-1 md:gap-3">
-            <h1 class="text-2xl md:text-4xl md:text-transparent md:[-webkit-text-stroke:1px_white] xl:text-5xl">APEX PROTOCOL</h1>
-            <h2 class="sm:text-xl md:text-2xl">AURORA BOREALIS</h2>
+            <h2>APEX PROTOCOL</h1>
+            <h3>AURORA BOREALIS</h2>
           </div>
 
           <!-- Listen + Share buttons -->
@@ -169,20 +169,20 @@
       </header>
 
       <!-- Stream it... -->
-      <section  class="hidden">
+      <section  class="stream-wrapper">
         <h1>STREAM IT YOUR WAY</h1>
 
         <!-- Platform icons -->
-        <div class="">
-          <button class="">
-            <img src="assets/icons/play-button.png" alt="Stream it on Monstercat player">
-            <span>PLAYER</span>
+        <div class="flex items-center">
+          <button class="bordered-button flex items-center gap-2 py-3.1! border-l-2">
+            <img class="social-icon" src="assets/icons/play-button.png" alt="Stream it on Monstercat player">
+            <span class="text-xs">PLAYER</span>
           </button>
-          <button><img src="assets/icons/bandcamp.png" alt="Stream it on Bandcamp"></button>
-          <button><img src="assets/icons/soundcloud.png" alt="Stream it on Soundcloud"></button>
-          <button><img src="assets/icons/apple.png" alt="Stream it on Apple Music"></button>
-          <button><img src="assets/icons/youtube.png" alt="Stream it on Youtube"></button>
-          <button><img src="assets/icons/spotify.png" alt="Stream it on Spotify"></button>
+          <button class="bordered-button"><img class="social-icon" src="assets/icons/bandcamp.png" alt="Stream it on Bandcamp"></button>
+          <button class="bordered-button"><img class="social-icon" src="assets/icons/soundcloud.png" alt="Stream it on Soundcloud"></button>
+          <button class="bordered-button"><img class="social-icon" src="assets/icons/apple.png" alt="Stream it on Apple Music"></button>
+          <button class="bordered-button"><img class="social-icon" src="assets/icons/youtube.png" alt="Stream it on Youtube"></button>
+          <button class="bordered-button"><img class="social-icon" src="assets/icons/spotify.png" alt="Stream it on Spotify"></button>
         </div>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -174,16 +174,34 @@
 
         <!-- Platform icons -->
         <div class="flex items-center">
-          <button class="bordered-button flex items-center gap-2 py-3.1! border-l-2">
+          <!-- Add "relative" to each button -->
+          <button class="bordered-button group relative flex items-center gap-2 py-3.1! border-l-2">
             <img class="social-icon" src="assets/icons/play-button.png" alt="Stream it on Monstercat player">
             <span class="text-xs">PLAYER</span>
+            <div class="tooltip group-hover:opacity-100">STREAM ON MONSTERCAT PLAYER</div>
           </button>
-          <button class="bordered-button"><img class="social-icon" src="assets/icons/bandcamp.png" alt="Stream it on Bandcamp"></button>
-          <button class="bordered-button"><img class="social-icon" src="assets/icons/soundcloud.png" alt="Stream it on Soundcloud"></button>
-          <button class="bordered-button"><img class="social-icon" src="assets/icons/apple.png" alt="Stream it on Apple Music"></button>
-          <button class="bordered-button"><img class="social-icon" src="assets/icons/youtube.png" alt="Stream it on Youtube"></button>
-          <button class="bordered-button"><img class="social-icon" src="assets/icons/spotify.png" alt="Stream it on Spotify"></button>
+          <button class="bordered-button group relative">
+            <img class="social-icon" src="assets/icons/bandcamp.png" alt="Stream it on Bandcamp">
+            <div class="tooltip">STREAM ON BANDCAMP</div>
+          </button>
+          <button class="bordered-button group relative">
+            <img class="social-icon" src="assets/icons/soundcloud.png" alt="Stream it on Soundcloud">
+            <div class="tooltip group-hover:opacity-100">STREAM ON SOUNDCLOUD</div>
+          </button>
+          <button class="bordered-button group relative">
+            <img class="social-icon" src="assets/icons/apple.png" alt="Stream it on Apple Music">
+            <div class="tooltip group-hover:opacity-100">STREAM ON APPLE</div>
+          </button>
+          <button class="bordered-button group relative">
+            <img class="social-icon" src="assets/icons/youtube.png" alt="Stream it on Youtube">
+            <div class="tooltip group-hover:opacity-100">STREAM ON YOUTUBE</div>
+          </button>
+          <button class="bordered-button group relative">
+            <img class="social-icon" src="assets/icons/spotify.png" alt="Stream it on Spotify">
+            <div class="tooltip group-hover:opacity-100">STREAM ON SPOTIFY</div>
+          </button>
         </div>
+
       </section>
 
       <!-- Track list -->

--- a/src/style.css
+++ b/src/style.css
@@ -55,8 +55,8 @@ body {
 .main-wrapper { /* For whole site */
     @apply
         relative z-10 overflow-x-hidden
-        flex flex-col items-center
-        w-full mt-28
+        flex flex-col items-center gap-5
+        w-fit mt-28
 
         md:mt-48
         ml:w-[58rem]
@@ -82,6 +82,13 @@ header {
         
         md:flex-row md:items-end md:pl-1 md:ml-5.5
 }
+.stream-wrapper {
+    @apply
+        flex flex-col items-start gap-4 
+        w-full mt-14 
+        
+        md:gap-7 ml:mt-20
+}
 
 /* Images & Icons */
 .topnav-logo { /* Logo for topbar */
@@ -95,7 +102,7 @@ header {
     @apply
         w-11
 }
-.nav-social-icon { /* Social icons for navigation */
+.social-icon { /* Social icons for navigation */
     @apply
         w-4.5
 }
@@ -123,6 +130,26 @@ header {
 }
 
 /* Text */
+h1 { /* For headings "STREAM IT YOUR WAY", "TRACK LIST", and "MUSIC VIDEO" */
+    @apply
+        text-xl 
+        
+        sm:text-3xl 
+        md:text-4xl 
+        xl:text-5xl
+}
+h2 { /* Album title */
+    @apply
+        text-2xl 
+        
+        md:text-4xl md:text-transparent md:[-webkit-text-stroke:1px_white] 
+        xl:text-5xl
+}
+h3 { /* Artist */
+    @apply
+        sm:text-xl
+        md:text-2xl
+}
 .rotating-text {
     @apply
         order-2 
@@ -151,6 +178,14 @@ header {
         hover:text-background hover:bg-primary hover:border-transparent
 
         md:pr-9 md:pl-7 md:py-3.5 md:text-base
+}
+.bordered-button {
+    @apply
+        p-3
+        border-e-2 border-y-2
+        cursor-pointer
+
+        md:p-6.5
 }
 
 /* Navigation */

--- a/src/style.css
+++ b/src/style.css
@@ -54,7 +54,7 @@ body {
 /* Wrappers */
 .main-wrapper { /* For whole site */
     @apply
-        relative z-10 overflow-x-hidden
+        relative z-10
         flex flex-col items-center gap-5
         w-fit mt-28
 
@@ -157,6 +157,35 @@ h3 { /* Artist */
         
         sm:text-lg
         md:absolute md:bottom-0 md:left-0 md:order-1 md:whitespace-nowrap md:origin-bottom-left md:-rotate-90
+}
+
+/* Tooltips */
+.tooltip {
+    @apply
+    absolute z-10
+    px-2 py-1
+    font-body font-semibold text-xs text-background whitespace-nowrap
+    bg-primary
+    bottom-full left-1/2 -translate-x-1/2 
+    invisible opacity-0 transition-opacity;
+}
+
+.tooltip::after {
+    @apply
+        absolute;
+        
+        content: '';
+        top: 100%; 
+        left: 50%;
+        transform: translateX(-50%);
+        border-width: 6px;
+        border-style: solid;
+        border-color: theme('colors.primary') transparent transparent transparent;
+}
+
+.group:hover .tooltip {
+    @apply 
+    visible opacity-100;
 }
 
 /* Links and buttons */


### PR DESCRIPTION
# What's in this PR?

Fully styles the *STREAM IT YOUR WAY* section and adds tooltips when hovering over each streaming platform.

## `index.html`
- Change album title and artist in the `header` to `h2` and `h3` respectively.
- Change the icon button/link from a `button` to an `a` element.
- Add a `div` inside each link for the tooltip text.
- Aside from these changes and assigning classes for styling, the overall structure is unchanged.
  - *Note: In the future, the `streaming` section will be combined with the `tracklist` and `music video` sections.

## `style.css`
- Organize heading classes: `h1`, `h2`, `h3`.
  - `h1`: section titles (streaming, tracklist, music video)
  - `h2`: album title in the header
  - `h3`: album artist in the header
- `.main-wrapper`:
  - Change `w-full` to `w-fit` to ensure content remains centered and moves with the `header`.
  - Remove `overflow-x-hidden` so tooltips are not clipped.
- `.stream-wrapper`: container for the streaming section.
- `.tooltip` and `.tooltip::after`: tooltip styles, with `.group:hover .tooltip` to show the tooltip on hover.

## `README.md`
- Check off the `Streaming` and `Tooltips` items in the checklist.