### PR TITLE
fix: change closing <button> tags to <a> in the streaming section

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,27 +179,27 @@
             <img class="social-icon" src="assets/icons/play-button.png" alt="Stream it on Monstercat player">
             <span class="text-xs">PLAYER</span>
             <div class="tooltip group-hover:opacity-100">STREAM ON MONSTERCAT PLAYER</div>
-          </button>
+          </a>
           <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/bandcamp.png" alt="Stream it on Bandcamp">
             <div class="tooltip">STREAM ON BANDCAMP</div>
-          </button>
+          </a>
           <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/soundcloud.png" alt="Stream it on Soundcloud">
             <div class="tooltip group-hover:opacity-100">STREAM ON SOUNDCLOUD</div>
-          </button>
+          </a>
           <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/apple.png" alt="Stream it on Apple Music">
             <div class="tooltip group-hover:opacity-100">STREAM ON APPLE</div>
-          </button>
+          </a>
           <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/youtube.png" alt="Stream it on Youtube">
             <div class="tooltip group-hover:opacity-100">STREAM ON YOUTUBE</div>
-          </button>
+          </a>
           <a class="bordered-button group relative">
             <img class="social-icon" src="assets/icons/spotify.png" alt="Stream it on Spotify">
             <div class="tooltip group-hover:opacity-100">STREAM ON SPOTIFY</div>
-          </button>
+          </a>
         </div>
 
       </section>


### PR DESCRIPTION
# What's in this PR?

Fixes a silly mistake.

## `index.html`
- Just changes the closing tags on the previously `button` elements. In the previous PR, it was changed from a button to a link. However, the closing tag was not changed from `<button>` to `<a>`.
- So fixed that :)