### PR TITLE
feat: style music video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This is a **WIP**! 🤫
 - [x] Streaming?
   - [x] Tooltips?
 - [x] Track List?
-- [ ] Music Video?
+- [x] Music Video?
 - [ ] Footer?
 - [ ] Background image?
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The goal is to recerate the structure, appearance, and behavior of **Monstercat'
 - Mobile-first layout
 - Responsive design
 - Layout, hover states, and interaction mimicry (attempt)
+- Blurred and transparent top navigation bar
+- Blurred background image
+- Cool Youtube video player (just an iframe, but don't worry about it)
+- Working music player
 
 <br>
 

--- a/index.html
+++ b/index.html
@@ -294,9 +294,9 @@
         </section>
 
         <!-- Music video -->
-        <section  class="hidden">
+        <section  class="flex flex-col gap-5 mb-30">
           <h1>MUSIC VIDEO</h1>
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/K4DyBUG242c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>    
+          <iframe class="w-full h-70 md:h-[25rem] ml:h-[33rem] lg:h-[34rem] xl:h-[40rem] 2xl:h-[52rem]" src="https://www.youtube.com/embed/K4DyBUG242c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>    
         </section>
       
       </div>

--- a/index.html
+++ b/index.html
@@ -294,9 +294,9 @@
         </section>
 
         <!-- Music video -->
-        <section  class="flex flex-col gap-5 mb-30">
+        <section  class="video-wrapper">
           <h1>MUSIC VIDEO</h1>
-          <iframe class="w-full h-70 md:h-[25rem] ml:h-[33rem] lg:h-[34rem] xl:h-[40rem] 2xl:h-[52rem]" src="https://www.youtube.com/embed/K4DyBUG242c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>    
+          <iframe src="https://www.youtube.com/embed/K4DyBUG242c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>    
         </section>
       
       </div>

--- a/src/style.css
+++ b/src/style.css
@@ -105,18 +105,11 @@ header {
         md:mr-0 md:ml-2 
         xl:mr-8
 }
-.track-item {
+.video-wrapper {
     @apply
-        flex justify-between items-center
+        flex flex-col gap-5
 }
-.duration-share {
-    @apply
-        flex items-center gap-2 
-        
-        md:gap-8 
-        xl:gap-12 
-        2xl:gap-18
-}
+
 
 /* Images & Icons */
 .topnav-logo { /* Logo for topbar */
@@ -155,6 +148,16 @@ header {
         ml:w-[25.5rem]
         xl:w-[30rem]
         2xl:w-[40.5rem]
+}
+iframe {
+    @apply
+        w-full h-70 
+        
+        md:h-[25rem] 
+        ml:h-[33rem] 
+        lg:h-[34rem] 
+        xl:h-[40rem] 
+        2xl:h-[52rem]
 }
 
 /* Text */
@@ -283,4 +286,18 @@ h3 { /* Artist */
         flex flex-col justify-between self-end
         w-[26rem] h-full pl-5 pr-8 py-7.5
         bg-background
+}
+
+/* Tracklist section stuff */
+.track-item {
+    @apply
+        flex justify-between items-center
+}
+.duration-share {
+    @apply
+        flex items-center gap-2 
+        
+        md:gap-8 
+        xl:gap-12 
+        2xl:gap-18
 }


### PR DESCRIPTION
# What's in this PR?

Fully styles the music video section of the page!

## `index.html`
- Replaces the `hidden` class in the Music Video `section` element to `video-wrapper` style class. See `style.css` changes below.

## `style.css`
- Adds two new classes for the Music Video section
  - `.video-wrapper` refers to the container used for the Music Video section, and it provides layout/spacing between the heading and the `iframe`
  - `iframe` CSS class directly styles any `iframe` HTML element (in this case, the only instance being the music video. It styles the video's dimensions. It is responsive, ballooning to bigger sizes when the screen width grows larger.
- Moves the `.track-item` and `.duration-share` from the "wrapper" section of the stylesheet because it doesn't belong there.

## `README.md`
- Checks off "Music Video?" from progress checklist
- Adds additional features
  - The future working music player is a feature anyways
  - The rest? idk