### PR TITLE
Feat: implement sidebar toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This is a **WIP**! 🤫
 - [x] Background image?
 
 #### Javascript 🌚
-- [ ] Sidebar navigation?
+- [x] Sidebar navigation?
 - [ ] Populate Tracklist with actual songs?
 - [ ] Working music player?
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
 
     <!-- Album cover background image -->
     <div class="background-img"></div>
+
+    <!-- Overlay for sidenav -->
+    <div id="sidenav-overlay" class="hidden"></div>
     
     <!-- Navigation wrapper -->
     <div>
@@ -36,7 +39,7 @@
               </div>
 
               <!-- hamburger menu -->
-              <button><img class="w-9" src="assets/icons/menu.png" alt="Open sidemenu button"></button>
+              <button><img id="sidenav-open-btn" class="w-9 cursor-pointer" src="assets/icons/menu.png" alt="Open sidemenu button"></button>
             </div>
 
             <!-- Socials (side) -->
@@ -55,7 +58,7 @@
         </div>
 
         <!-- Sidenav -->
-        <nav class="sidenav hidden!">
+        <nav id="sidenav" class="sidenav transform transition-transform ease-in-out translate-x-full">
 
           <!-- Sidenav top -->
           <div class="flex flex-col gap-16">
@@ -68,7 +71,7 @@
                 <span class="font-body font-bold tracking-normal text-2xl">monstercat</span>
               </a>
               <!-- Close button -->
-              <button><img class="close-icon" src="assets/icons/x.png" alt="Close sidemenu button"></button>
+              <button><img id="sidenav-close-btn" class="close-icon" src="assets/icons/x.png" alt="Close sidemenu button"></button>
             </div>
 
             <!-- Nav links -->

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
               </div>
 
               <!-- hamburger menu -->
-              <button><img id="sidenav-open-btn" class="w-9 cursor-pointer" src="assets/icons/menu.png" alt="Open sidemenu button"></button>
+              <button><img id="sidenav-open-btn" class="sidenav-toggle-icon" src="assets/icons/menu.png" alt="Open sidemenu button"></button>
             </div>
 
             <!-- Socials (side) -->
@@ -71,7 +71,7 @@
                 <span class="font-body font-bold tracking-normal text-2xl">monstercat</span>
               </a>
               <!-- Close button -->
-              <button><img id="sidenav-close-btn" class="close-icon" src="assets/icons/x.png" alt="Close sidemenu button"></button>
+              <button><img id="sidenav-close-btn" class="sidenav-toggle-icon" src="assets/icons/x.png" alt="Close sidemenu button"></button>
             </div>
 
             <!-- Nav links -->

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
         </div>
 
         <!-- Sidenav -->
-        <nav id="sidenav" class="sidenav transform transition-transform ease-in-out translate-x-full">
+        <nav id="sidenav" class="sidenav translate-x-full">
 
           <!-- Sidenav top -->
           <div class="flex flex-col gap-16">

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,16 @@
 import './style.css'
+
+// ===========================
+// # Toggle sidenav menu
+// ===========================
+const sidenavOpenBtn = document.getElementById('sidenav-open-btn');
+const sidenavCloseBtn = document.getElementById('sidenav-close-btn');
+const sidenav = document.getElementById('sidenav');
+const overlay = document.getElementById('sidenav-overlay');
+
+function openSidenav() { sidenav.classList.remove('translate-x-full'); overlay.classList.remove('hidden') }
+function closeSidenav() { sidenav.classList.add('translate-x-full'); overlay.classList.add('hidden') }
+
+sidenavOpenBtn.addEventListener('click', openSidenav);
+sidenavCloseBtn.addEventListener('click', closeSidenav);
+overlay.addEventListener('click', closeSidenav);

--- a/src/style.css
+++ b/src/style.css
@@ -314,6 +314,7 @@ input {
         flex flex-col justify-between self-end
         w-[26rem] h-full pl-5 pr-8 py-7.5
         bg-background
+        transform transition-transform duration-300 ease-in-out
 }
 #sidenav-overlay {
     @apply

--- a/src/style.css
+++ b/src/style.css
@@ -144,6 +144,7 @@ footer {
 .close-icon { /* Sidemenu close button icon */
     @apply
         w-9
+        cursor-pointer
 }
 .background-img {
     @apply
@@ -248,7 +249,6 @@ input {
     bottom-full left-1/2 -translate-x-1/2 
     invisible opacity-0 transition-opacity;
 }
-
 .tooltip::after {
     @apply
         absolute;
@@ -261,7 +261,6 @@ input {
         border-style: solid;
         border-color: theme('colors.primary') transparent transparent transparent;
 }
-
 .group:hover .tooltip {
     @apply 
     visible opacity-100;
@@ -311,10 +310,14 @@ input {
 }
 .sidenav { /* Hidden side menu */
     @apply
-        fixed z-99
+        fixed z-100 top-0 right-0
         flex flex-col justify-between self-end
         w-[26rem] h-full pl-5 pr-8 py-7.5
         bg-background
+}
+#sidenav-overlay {
+    @apply
+        fixed inset-0 z-[99]
 }
 
 /* Tracklist section stuff */

--- a/src/style.css
+++ b/src/style.css
@@ -141,7 +141,7 @@ footer {
     @apply
         w-4.5
 }
-.close-icon { /* Sidemenu close button icon */
+.sidenav-toggle-icon { /* Sidemenu close button icon */
     @apply
         w-9
         cursor-pointer


### PR DESCRIPTION
# What's in this PR?

The sidenav menu can now be toggled open and closed.

## `index.html`
- Add a new element for the sidenav overlay
- Add relevant utility classes to the sidenav section
  - Add to toggle buttons and the sidenav `nav` container

## `style.css`
- Combine the hamburger menu button and close menu button icon into one class: `.sidenav-toggle-icon`
- Add layouts, `transform`, and `transition` properties to `.sidenav`
- Add `#sidenav-overlay`: styles the overlay for when the sidenav menu is open

## `main.js`
- add functions:
  - `function openSidenav()`: to open sidenav :shrug: 
  - `function closeSidenav()`: to close sidenav :shrug: 

## `README.md`
- Update progress checklist:
  - `sidebar navigation?`